### PR TITLE
Switch from colorful console output to logrus logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Golang implementation of sending redis metrics to statsd
 **inspiration from:** https://github.com/keenlabs/redis-statsd
 
 ```
-➜  stadis git:(master) ✗ ./stadis --help
 NAME:
    stadis - get redis info and submit to statsd
 
@@ -15,7 +14,9 @@ USAGE:
    stadis [global options] command [command options] [arguments...]
 
 VERSION:
-   0.0.1
+   0.0.2
+
+AUTHOR(S):
 
 COMMANDS:
    help, h	Shows a list of commands or help for one command
@@ -25,6 +26,7 @@ GLOBAL OPTIONS:
    --statsd-host, -s "localhost:8125"	host:port of statsd servier
    --prefix, -p 			host:port of redis servier [$HOSTNAME]
    --interval, -i "5000"		time in milliseconds to periodically check redis
+   --debug, -d				enable debug logging
    --help, -h				show help
    --version, -v			print the version
 ```


### PR DESCRIPTION
While the colorful console messages are nice for debugging,
having a robust logging library allows for such things as json
output for ingestion by other tools. Logrus seems like a simple
and powerful library, with support for pluggable backends and filters,
while maintaining compatibility with the built-in log library.

This PR replaces the color output with logrus logging and adds a `--debug`
flag that enables displaying metrics. Otherwise only WARNs and ERRORs are
shown. There is currently no support for specifying output format or
filtering, but those can come later.

Does this seem like a reasonable way to go about logging? I'm certainly
open to suggestions.
